### PR TITLE
AEGIS-134 Add RequestDate for freeform multi-date selection

### DIFF
--- a/models/request-date.model.ts
+++ b/models/request-date.model.ts
@@ -1,0 +1,24 @@
+import {
+  AllowNull,
+  BelongsTo,
+  Column,
+  ForeignKey,
+  Model,
+  Table,
+} from 'sequelize-typescript';
+import Request from './request.model';
+
+@Table
+export default class RequestDate extends Model<RequestDate> {
+  @AllowNull(false)
+  @ForeignKey(() => Request)
+  @Column
+  requestId!: number;
+
+  @BelongsTo(() => Request)
+  request!: Request;
+
+  @AllowNull(false)
+  @Column
+  date!: Date;
+}

--- a/models/request.model.ts
+++ b/models/request.model.ts
@@ -3,23 +3,22 @@ import {
   BelongsTo,
   Column,
   ForeignKey,
+  HasMany,
   Model,
   Table,
 } from 'sequelize-typescript';
 import { DataTypes } from 'sequelize';
 import Member from './member.model';
+import RequestDate from './request-date.model';
 
 @Table
 export default class Request extends Model<Request> {
-  @Column
-  startDate!: Date;
-
-  @Column
-  endDate!: Date;
-
   @AllowNull(false)
   @Column
   reason!: string;
+
+  @HasMany(() => RequestDate)
+  dates!: RequestDate[];
 
   @BelongsTo(() => Member)
   member!: Member;

--- a/src/app.ts
+++ b/src/app.ts
@@ -760,12 +760,25 @@ app.put(
 
 app.delete('/requests/batch', body().isArray(), async (req, res) => {
   try {
-    await Request.destroy({
-      where: {
-        id: {
-          [Op.in]: req.body,
+    await sequelize.transaction(async (t) => {
+      // Delete all request date objects
+      await RequestDate.destroy({
+        where: {
+          requestId: {
+            [Op.in]: req.body,
+          },
         },
-      },
+        transaction: t,
+      });
+
+      await Request.destroy({
+        where: {
+          id: {
+            [Op.in]: req.body,
+          },
+        },
+        transaction: t,
+      });
     });
 
     return res.status(200).send('Requests deleted');


### PR DESCRIPTION
Allows multiple dates per request.

API calls involving requests will "flatten" the request dates before returning.

```json
{
    "reason": "Some reason",
	"dates:": [
		{
			"date": "2022-01-01"
		}
	]
}
```

will instead be returned as


```json
{
    "reason": "Some reason",
	"dates:": [ "2022-01-01"]
}
```